### PR TITLE
Modified session template creation in DataClayWrapper

### DIFF
--- a/dataclay-proxy/src/api/DataClayWrapper.java
+++ b/dataclay-proxy/src/api/DataClayWrapper.java
@@ -202,7 +202,7 @@ public class DataClayWrapper {
 			obj = new Session(objectData);
 			break;
 		case "session-template":
-			// obj = new SessionTemplate(objectData);
+			obj = new SessionTemplate(objectData);
 			break;
 		case "user-param":
 			// obj = new UserParam(objectData);


### PR DESCRIPTION
Session Template creation was wrong in DataClayWrapper, since CIMI is creating session templates, this should be fixed.