### PR TITLE
switch to using kebab case

### DIFF
--- a/dataclay-proxy/project.clj
+++ b/dataclay-proxy/project.clj
@@ -50,6 +50,7 @@
   [[org.clojure/clojure]
    [org.clojure/tools.logging]
    [org.clojure/data.json]
+   [camel-snake-kebab "0.4.0"]
    [ring]
    [http-kit "2.2.0"]
    [dataclay.mf2c/wrapper "trunk"]

--- a/dataclay-proxy/src/com/sixsq/dataclay/wrapper.clj
+++ b/dataclay-proxy/src/com/sixsq/dataclay/wrapper.clj
@@ -19,7 +19,8 @@
    Java. This exists solely to make testing easier."
   (:refer-clojure :exclude [read update])
   (:require
-    [clojure.tools.logging :as log])
+    [clojure.tools.logging :as log]
+    [camel-snake-kebab.core :refer [->kebab-case]])
   (:import
     (api DataClayWrapper)))
 
@@ -27,8 +28,9 @@
 (defn create
   [type uuid data]
   (try
-    (let [response (DataClayWrapper/create type uuid data)]
-      (log/info "wrapper create response:" response)
+    (let [dc-type (->kebab-case type)
+          response (DataClayWrapper/create dc-type uuid data)]
+      (log/info "wrapper create response:" dc-type response)
       response)
     (catch Exception ex
       (log/info "wrapper create exception:" (str ex))
@@ -38,8 +40,9 @@
 (defn read
   [type uuid]
   (try
-    (let [response (DataClayWrapper/read type uuid)]
-      (log/info "wrapper read response:" response)
+    (let [dc-type (->kebab-case type)
+          response (DataClayWrapper/read dc-type uuid)]
+      (log/info "wrapper read response:" dc-type response)
       response)
     (catch Exception ex
       (log/info "wrapper read exception:" (str ex))
@@ -49,8 +52,9 @@
 (defn delete
   [type uuid]
   (try
-    (let [response (DataClayWrapper/delete type uuid)]
-      (log/info "wrapper delete response:" response)
+    (let [dc-type (->kebab-case type)
+          response (DataClayWrapper/delete dc-type uuid)]
+      (log/info "wrapper delete response:" dc-type response)
       response)
     (catch Exception ex
       (log/info "wrapper delete exception:" (str ex))
@@ -60,8 +64,9 @@
 (defn update
   [type uuid data]
   (try
-    (let [response (DataClayWrapper/update type uuid data)]
-      (log/info "wrapper update response:" response)
+    (let [dc-type (->kebab-case type)
+          response (DataClayWrapper/update dc-type uuid data)]
+      (log/info "wrapper update response:" dc-type response)
       response)
     (catch Exception ex
       (log/info "wrapper update exception:" (str ex))
@@ -71,8 +76,9 @@
 (defn query
   [collection-id filter user-name user-role]
   (try
-    (let [response (DataClayWrapper/query collection-id filter user-name user-role)]
-      (log/info "wrapper query response:" response)
+    (let [dc-collection-id (->kebab-case collection-id)
+          response (DataClayWrapper/query dc-collection-id filter user-name user-role)]
+      (log/info "wrapper query response:" dc-collection-id response)
       response)
     (catch Exception ex
       (log/info "wrapper query exception:" (str ex))


### PR DESCRIPTION
Switch to using kebab case to work around issue with dataClay queries that have resource links.

Connected to slipstream/SlipStreamServer#1737.